### PR TITLE
adding `conda activate build`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,9 @@ jobs:
         run: python -m pip install .
 
       - name: Build documents
-        run: make -C doc html
+        run: |
+          conda activate build
+          make -C doc html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The current error says that `sphinx_rtd_theme` module is not installed. The installation step explicitly says it is installed. I think that an error is that the environment it was installed into is not active when the docs are made using `make`. But I'm not sure.