### PR TITLE
Avoid lambda flake8 error with private function

### DIFF
--- a/diffpy/snmf/containers.py
+++ b/diffpy/snmf/containers.py
@@ -36,7 +36,7 @@ class ComponentSignal:
         Returns
         -------
         NDArray[float64]
-            The interpolated values over the stretched grid.
+          Interpolated values of the self.iq values over the grid that has been adjusted by the stretching_factor
         """
 
         normalized_grid = np.arange(len(self.grid))

--- a/diffpy/snmf/containers.py
+++ b/diffpy/snmf/containers.py
@@ -8,7 +8,7 @@ class ComponentSignal:
     ----------
     grid: 1d array of floats
       The vector containing the grid points of the component.
-
+    iq: 1d array of floats
       The intensity/g(r) values of the component.
     weights: 1d array of floats
       The vector containing the weight of the component signal for each signal.
@@ -25,23 +25,6 @@ class ComponentSignal:
         self.stretching_factors = np.ones(number_of_signals) + np.random.randn(number_of_signals) * perturbation
         self.id = int(id_number)
 
-    def _interpolate_stretching_factor(self, stretching_factor):
-        """Interpolates the intensity values over a normalized grid scaled by a given stretching factor.
-
-        Parameters
-        ----------
-        stretching_factor : float
-            The factor by which to stretch the grid.
-
-        Returns
-        -------
-        NDArray[float64]
-          Interpolated values of the self.iq values over the grid that has been adjusted by the stretching_factor
-        """
-
-        normalized_grid = np.arange(len(self.grid))
-        return np.interp(normalized_grid / stretching_factor, normalized_grid, self.iq, left=0, right=0)
-
     def apply_stretch(self, m):
         """Applies a stretching factor to a component
 
@@ -53,14 +36,17 @@ class ComponentSignal:
         Returns
         -------
         tuple of 1d arrays
-          The tuple of vectors where one vector is the stretched component, one vector is the 1st derivative
-          of the stretching operation, and one vector is the second derivative of the stretching operation.
+          The tuple of vectors where one vector is the stretched component, one vector is the 1st derivative of the
+          stretching operation, and one vector is the second derivative of the stretching operation.
         """
-
-        derivative_func = numdifftools.Derivative(self._interpolate_stretching_factor)
+        normalized_grid = np.arange(len(self.grid))
+        func = lambda stretching_factor: np.interp(  # noqa: E731
+            normalized_grid / stretching_factor, normalized_grid, self.iq, left=0, right=0
+        )
+        derivative_func = numdifftools.Derivative(func)
         second_derivative_func = numdifftools.Derivative(derivative_func)
 
-        stretched_component = self._interpolate_stretching_factor(self.stretching_factors[m])
+        stretched_component = func(self.stretching_factors[m])
         stretched_component_gra = derivative_func(self.stretching_factors[m])
         stretched_component_hess = second_derivative_func(self.stretching_factors[m])
 

--- a/diffpy/snmf/containers.py
+++ b/diffpy/snmf/containers.py
@@ -40,13 +40,13 @@ class ComponentSignal:
           stretching operation, and one vector is the second derivative of the stretching operation.
         """
         normalized_grid = np.arange(len(self.grid))
-        func = lambda stretching_factor: np.interp(  # noqa: E731
+        interpolate_intensity = lambda stretching_factor: np.interp(  # noqa: E731
             normalized_grid / stretching_factor, normalized_grid, self.iq, left=0, right=0
         )
-        derivative_func = numdifftools.Derivative(func)
+        derivative_func = numdifftools.Derivative(interpolate_intensity)
         second_derivative_func = numdifftools.Derivative(derivative_func)
 
-        stretched_component = func(self.stretching_factors[m])
+        stretched_component = interpolate_intensity(self.stretching_factors[m])
         stretched_component_gra = derivative_func(self.stretching_factors[m])
         stretched_component_hess = second_derivative_func(self.stretching_factors[m])
 


### PR DESCRIPTION
As provided in the previous comment: https://github.com/diffpy/diffpy.snmf/pull/54#discussion_r1701736654

> For these lambda flake8 errors we would normally see if the function is being used in **more than one place,** and if it is, define a private function somewhere outside the main part of the code.

I created a private function called `_interpolate_stretching_factor` in the `ComponentSignal` class since the function has been used more than once. Thank you for the feedback.

Please confirm my function description.

- comments removed
- CI, pre-commit ✅

