### PR TITLE
Cookiecutter: add 2023 to copyright and clarify tutorial to be added

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, The Trustees of Columbia University
+Copyright (c) 2023-2024, The Trustees of Columbia University
 in the City of New York.
 All rights reserved.
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -1,6 +1,6 @@
 .. _quick_start:
 
-Tutorial
+Tutorial (To be addded)
 #################
 
 Welcome! This will be a quick tutorial to accquaint users with `snmf`.


### PR DESCRIPTION
- URLs work, doc compiles

Is there a paper for `snmf` ? @sbillinge ? 

In the next PR, I will make a PR from `cookie` to `main` for doc hosting.
