### PR TITLE
Bump Python 3.9 to 3.12 in news CI

### DIFF
--- a/.github/workflows/check-news-item.yml
+++ b/.github/workflows/check-news-item.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
       - run: pip install PyGithub

--- a/.github/workflows/check-news-item.yml
+++ b/.github/workflows/check-news-item.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
       - run: pip install PyGithub

--- a/news/CI-news-version.rst
+++ b/news/CI-news-version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Python version from 3.9 to 3.12 in CI news item
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
I will test it.

Closes https://github.com/diffpy/diffpy.snmf/issues/80