### PR TITLE
Update .coveragerc to include dfifpy.snmf instead of src

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 source =
-    src
+    diffpy.snmf
 [report]
 omit =
     */python?.?/*


### PR DESCRIPTION
Crosschecked with `diffpy.utils` - https://github.com/diffpy/diffpy.utils/blob/main/.coveragerc 

and locally codecov works.

```
                                 Stmts   Miss  Cover
----------------------------------------------------
diffpy/snmf/__init__.py              2      0   100%
diffpy/snmf/containers.py           22      0   100%
diffpy/snmf/factorizers.py           6      0   100%
diffpy/snmf/io.py                   33     33     0%
diffpy/snmf/optimizers.py           13      0   100%
diffpy/snmf/polynomials.py          12      0   100%
diffpy/snmf/stretchednmfapp.py      24     24     0%
diffpy/snmf/subroutines.py         126     11    91%
----------------------------------------------------
                                   238     68    71%
```