### PR TITLE
Configure automatic spelling check via codespell within pre-commit

### DIFF
--- a/.codespell/ignore_lines.txt
+++ b/.codespell/ignore_lines.txt
@@ -1,0 +1,4 @@
+;; Please include filenames and explanations for each ignored line.
+;; See https://docs.openverse.org/meta/codespell.html for docs.
+
+

--- a/.codespell/ignore_lines.txt
+++ b/.codespell/ignore_lines.txt
@@ -1,4 +1,2 @@
 ;; Please include filenames and explanations for each ignored line.
 ;; See https://docs.openverse.org/meta/codespell.html for docs.
-
-

--- a/.codespell/ignore_words.txt
+++ b/.codespell/ignore_words.txt
@@ -9,5 +9,3 @@ socio-economic
 
 ;; Frobenius norm used in np.linalg.norm
 fro
-
-

--- a/.codespell/ignore_words.txt
+++ b/.codespell/ignore_words.txt
@@ -1,7 +1,7 @@
 ;; Please include explanations for each ignored word (lowercase) using full sentences.
 ;; See https://docs.openverse.org/meta/codespell.html for docs.
 
-;; short-form form materials in a journal title
+;; abbreviation for "materials" often used in a journal title
 mater
 
 ;; alternative use of socioeconomic

--- a/.codespell/ignore_words.txt
+++ b/.codespell/ignore_words.txt
@@ -1,4 +1,4 @@
-;; Please include explanations for each ignored word (lowercase) using full sentences.
+;; Please include explanations for each ignored word (lowercase).
 ;; See https://docs.openverse.org/meta/codespell.html for docs.
 
 ;; abbreviation for "materials" often used in a journal title

--- a/.codespell/ignore_words.txt
+++ b/.codespell/ignore_words.txt
@@ -1,0 +1,13 @@
+;; Please include explanations for each ignored word (lowercase) using full sentences.
+;; See https://docs.openverse.org/meta/codespell.html for docs.
+
+;; short-form form materials in a journal title
+mater
+
+;; alternative use of socioeconomic
+socio-economic
+
+;; Frobenius norm used in np.linalg.norm
+fro
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
         name: Prevent Commit to Main Branch
         args: ["--branch", "main"]
         stages: [pre-commit]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+    - id: codespell
+      additional_dependencies:
+        - tomli

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@ Release Notes
 
 **Fixed:**
 
-* Updated REAMDE instructions for pip and conda-forge install
-* Updated REAMDE instructions to check for successful installation
+* Updated README instructions for pip and conda-forge install
+* Updated README instructions to check for successful installation
 
 
 0.1.2

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ trying to commit again.
 
 Improvements and fixes are always appreciated.
 
-Before contribuing, please read our `Code of Conduct <https://github.com/diffpy/diffpy.snmf/blob/main/CODE_OF_CONDUCT.rst>`_.
+Before contributing, please read our `Code of Conduct <https://github.com/diffpy/diffpy.snmf/blob/main/CODE_OF_CONDUCT.rst>`_.
 
 Contact
 -------

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -1,6 +1,6 @@
 .. _quick_start:
 
-Tutorial (To be addded)
+Tutorial (To be added)
 #################
 
 Welcome! This will be a quick tutorial to accquaint users with `snmf`.
@@ -18,5 +18,5 @@ Add extra tutorials here
 Bug Reports
 ===========
 
-Please enjoy using our software! If you come accross any bugs in the
+Please enjoy using our software! If you come across any bugs in the
 application, please report them to diffpy-users@googlegroups.com.

--- a/news/codespell.rst
+++ b/news/codespell.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add spelling check pre-commit via Codespell
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}
 
+[tool.codespell]
+exclude-file = ".codespell/ignore_lines.txt"
+ignore-words = ".codespell/ignore_words.txt"
+skip = "*.cif"
+
 [tool.black]
 line-length = 115
 include = '\.pyi?$'

--- a/src/diffpy/snmf/polynomials.py
+++ b/src/diffpy/snmf/polynomials.py
@@ -8,7 +8,7 @@ def rooth(linear_coefficient, constant_term):
 
     Parameters
     ----------
-    linear_coefficient: nd array like of floats
+    linear_coefficient: ndarray like of floats
         The matrix coefficient of the linear term
     constant_term: 0d array like, 1d array like of floats or scalar
         The constant scalar term of the problem

--- a/src/diffpy/snmf/subroutines.py
+++ b/src/diffpy/snmf/subroutines.py
@@ -362,7 +362,7 @@ def update_weights_matrix(
       The matrx containing the stretching factors of the calculated component signals. Has dimensions K x M
       where K is the number of component signals and M is the number of XRD/PDF patterns.
 
-    component_matrix: 2d array lik
+    component_matrix: 2d array like
       The matrix containing the unstretched calculated component signals. Has dimensions N x K where N is the
       length of the signals and K is the number of component signals.
 


### PR DESCRIPTION
Will add to the cookiecutter repo after further finding common terms to ignore in diffpy.srmise and diffpy.utils 

Ref: https://github.com/Billingegroup/cookiecutter/issues/168