### PR TITLE
fix: make changes for conda-forge compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,10 @@ The preferred method is conda::
         conda create -n diffpy.stretched-nmf_env diffpy.stretched-nmf
         conda activate diffpy.stretched-nmf_env
 
+For interactive plotting with ``show_plots=True``, use a GUI-capable desktop
+environment. Conda installs use ``matplotlib-base``, which is sufficient for
+plotting but still depends on an available interactive Matplotlib backend.
+
 Alternatively, install from PyPI with pip::
 
         pip install diffpy.stretched-nmf

--- a/README.rst
+++ b/README.rst
@@ -83,13 +83,13 @@ For source installs (after cloning the repo)::
 
 Quick check::
 
-        diffpy.stretched-nmf --version
+        snmf --version
         python -c "import diffpy.stretched_nmf; print(diffpy.stretched_nmf.__version__)"
 
 
 To view the basic usage and available commands, type ::
 
-        diffpy.stretched-nmf -h
+        snmf -h
 
 Getting Started
 ---------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -17,6 +17,10 @@ The preferred method is conda:
    conda create -n diffpy.stretched-nmf_env diffpy.stretched-nmf
    conda activate diffpy.stretched-nmf_env
 
+For interactive plotting with ``show_plots=True``, use a GUI-capable desktop
+environment. Conda installs use ``matplotlib-base``, which is sufficient for
+plotting but still depends on an available interactive Matplotlib backend.
+
 Alternatively, install from PyPI with pip:
 
 .. code-block:: bash

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -40,7 +40,7 @@ Verify the CLI and Python import:
 
 .. code-block:: bash
 
-   diffpy.stretched-nmf --version
+   snmf --version
    python -c "import diffpy.stretched_nmf; print(diffpy.stretched_nmf.__version__)"
 
 Basic usage

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* Rename cli entrypoint to 'snmf' from 'diffpy.stretched-nmf'
 
 **Deprecated:**
 

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -16,6 +16,7 @@
 
 **Fixed:**
 
+* Produce an error if test files are missing
 * Use matplotlib-base when installing with conda-forge
 
 **Security:**

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Use matplotlib-base when installing with conda-forge
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-"diffpy.stretched-nmf" = "diffpy.stretched_nmf.snmf_app:main"
+"snmf" = "diffpy.stretched_nmf.snmf_app:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,5 +1,5 @@
 numpy
-matplotlib
+matplotlib-base
 scipy
 cvxpy
 diffpy.utils

--- a/src/diffpy/stretched_nmf/snmf_app.py
+++ b/src/diffpy/stretched_nmf/snmf_app.py
@@ -5,7 +5,7 @@ from diffpy.stretched_nmf.version import __version__  # noqa
 
 def main():
     parser = argparse.ArgumentParser(
-        prog="diffpy.stretched-nmf",
+        prog="snmf",
         description=(
             "A python package implementing the stretched NMF algorithm.\n\n"
             "For more information, visit: "
@@ -23,7 +23,7 @@ def main():
     args = parser.parse_args()
 
     if args.version:
-        print(f"diffpy.stretched-nmf {__version__}")
+        print(f"snmf {__version__}")
     else:
         # Default behavior when no arguments are given
         parser.print_help()

--- a/src/diffpy/stretched_nmf/snmf_app.py
+++ b/src/diffpy/stretched_nmf/snmf_app.py
@@ -8,6 +8,9 @@ def main():
         prog="snmf",
         description=(
             "A python package implementing the stretched NMF algorithm.\n\n"
+            "Currently, this project is used by importing "
+            "`SNMFOptimizer` in Python rather than through a command-line "
+            "workflow.\n\n"
             "For more information, visit: "
             "https://github.com/diffpy/diffpy.stretched-nmf/"
         ),

--- a/tests/test_snmf_optimizer.py
+++ b/tests/test_snmf_optimizer.py
@@ -5,9 +5,11 @@ import pytest
 
 from diffpy.stretched_nmf.snmf_class import SNMFOptimizer
 
-DATA_DIR = Path(__file__).parent / "inputs/test_snmf_optimizer"
+DATA_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "docs/examples/data/XRD-MgMnO-YCl-real"
+)
 
-# Skip the test entirely if any inputs file is missing
 _required = [
     "init-components.txt",
     "source-matrix.txt",
@@ -15,18 +17,21 @@ _required = [
     "init-weights.txt",
 ]
 _missing = [f for f in _required if not (DATA_DIR / f).exists()]
-pytestmark = pytest.mark.skipif(
-    _missing, reason=f"Missing test data files: {_missing}"
-)
 
 
 @pytest.fixture(scope="module")
 def inputs():
+    if _missing:
+        pytest.fail(
+            f"Missing required test data files in {DATA_DIR}: {_missing}"
+        )
     return {
         "components": np.loadtxt(
             DATA_DIR / "init-components.txt", dtype=float
         ),
-        "source": np.loadtxt(DATA_DIR / "source-matrix.txt", dtype=float),
+        "source": np.loadtxt(
+            DATA_DIR / "source-matrix.txt", dtype=float, skiprows=4
+        ),
         "stretch": np.loadtxt(DATA_DIR / "init-stretch.txt", dtype=float),
         "weights": np.loadtxt(DATA_DIR / "init-weights.txt", dtype=float),
     }


### PR DESCRIPTION
@sbillinge Thanks for your patience while I had put this off. This should be everything we talked about for 0.2.1. The one place I don't think we came to an agreement was around python version. Currently the recipe says <3.14 because we only support up to 3.13. I believe the original plan was that supporting 3.14 would come with snmf 0.3. Does that clear it up?