### PR TITLE
fix: make fitting test self-contained

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3
+  python: python3.13
 ci:
   autofix_commit_msg: |
     [pre-commit.ci] auto fixes from pre-commit hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ ci:
   submodules: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -21,45 +21,45 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.0a3
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         name: Prevent Commit to Main Branch
         args: ["--branch", "main"]
         stages: [pre-commit]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
   # prettier - multi formatter for .json, .yml, and .md files
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         additional_dependencies:
           - "prettier@^3.2.4"
   # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/s-weigand/docformatter
-    rev: 5757c5190d95e5449f102ace83df92e7d3b06c6c
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.13
+  python: python3
 ci:
   autofix_commit_msg: |
     [pre-commit.ci] auto fixes from pre-commit hooks

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -18,6 +18,7 @@
 
 * Produce an error if test files are missing
 * Use matplotlib-base when installing with conda-forge
+* Update to docformatter 1.7.8
 
 **Security:**
 

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* Rename cli entrypoint to 'snmf' from 'diffpy.stretched-nmf'
 
 **Deprecated:**
 

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -16,6 +16,7 @@
 
 **Fixed:**
 
+* Produce an error if test files are missing
 * Use matplotlib-base when installing with conda-forge
 
 **Security:**

--- a/news/forge-cleanup.rst
+++ b/news/forge-cleanup.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Use matplotlib-base when installing with conda-forge
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/stretched_nmf/snmf_class.py
+++ b/src/diffpy/stretched_nmf/snmf_class.py
@@ -117,7 +117,6 @@ class SNMFOptimizer:
         show_plots : bool
             Enables plotting at each step of the decomposition. Optional.
         """
-
         if n_components is not None and n_components < 1:
             raise ValueError("n_components must be a positive integer.")
 
@@ -583,7 +582,6 @@ class SNMFOptimizer:
         -------
         residuals : (signal_len, n_signals) array
         """
-
         if components is None:
             components = self.components_
         if weights is None:
@@ -651,7 +649,6 @@ class SNMFOptimizer:
         dd_stretched_components : array, shape (signal_len, n_comps * n_sigs)
             Second derivatives with respect to stretch.
         """
-
         # --- Defaults ---
         if components is None:
             components = self.components_
@@ -724,7 +721,6 @@ class SNMFOptimizer:
         """Computes the transformation matrix `stretch_transformed` for
         residuals, using scaling matrix `stretch` and weight
         coefficients `weights`."""
-
         if stretch is None:
             stretch = self.stretch_
         if weights is None:
@@ -851,7 +847,6 @@ class SNMFOptimizer:
     def _update_components(self):
         """Updates `components` using gradient-based optimization with
         adaptive step size."""
-
         # Compute stretched components using the interpolation function
         stretched_components, _, _ = (
             self._compute_stretched_components()
@@ -934,7 +929,6 @@ class SNMFOptimizer:
         """Updates weights by building the stretched component matrix
         `stretched_comps` with np.interp and solving a quadratic program
         for each signal."""
-
         sample_indices = np.arange(self.signal_length_)
         for signal in range(self.n_signals_):
             # Stretch factors for this signal across components:
@@ -999,7 +993,6 @@ class SNMFOptimizer:
     def _update_stretch(self):
         """Updates stretching matrix using constrained optimization
         (equivalent to fmincon in MATLAB)."""
-
         if self.verbose:
             print("Updating stretch factors...")
 
@@ -1147,7 +1140,6 @@ def _reconstruct_matrix(components, weights, stretch):
     -------
     reconstructed_matrix : (signal_len, n_signals) array
     """
-
     signal_len = components.shape[0]
     n_components = components.shape[1]
     n_signals = weights.shape[1]

--- a/tests/test_snmf_optimizer.py
+++ b/tests/test_snmf_optimizer.py
@@ -1,62 +1,42 @@
-from pathlib import Path
-
 import numpy as np
 import pytest
 
 from diffpy.stretched_nmf.snmf_class import SNMFOptimizer
 
-DATA_DIR = (
-    Path(__file__).resolve().parents[1]
-    / "docs/examples/data/XRD-MgMnO-YCl-real"
-)
 
-_required = [
-    "init-components.txt",
-    "source-matrix.txt",
-    "init-stretch.txt",
-    "init-weights.txt",
-]
-_missing = [f for f in _required if not (DATA_DIR / f).exists()]
+def test_fit_recovers_rank_one_factors():
+    expected_components = np.array(
+        [
+            [0.20],
+            [0.75],
+            [1.20],
+            [0.80],
+            [0.30],
+        ]
+    )
+    expected_weights = np.array(
+        [
+            [0.20, 0.60, 1.00, 0.40],
+        ]
+    )
+    source = expected_components @ expected_weights
 
-
-@pytest.fixture(scope="module")
-def inputs():
-    if _missing:
-        pytest.fail(
-            f"Missing required test data files in {DATA_DIR}: {_missing}"
-        )
-    return {
-        "components": np.loadtxt(
-            DATA_DIR / "init-components.txt", dtype=float
-        ),
-        "source": np.loadtxt(
-            DATA_DIR / "source-matrix.txt", dtype=float, skiprows=4
-        ),
-        "stretch": np.loadtxt(DATA_DIR / "init-stretch.txt", dtype=float),
-        "weights": np.loadtxt(DATA_DIR / "init-weights.txt", dtype=float),
-    }
-
-
-@pytest.mark.slow
-def test_final_objective_below_threshold(inputs):
     model = SNMFOptimizer(
+        n_components=1,
         show_plots=False,
         random_state=1,
-        min_iter=5,
-        max_iter=5,
-        rho=1e12,
-        eta=610,
+        min_iter=0,
+        max_iter=2,
+        rho=0.0,
+        eta=0.0,
     )
-    model.fit(
-        source_matrix=inputs["source"],
-        init_weights=inputs["weights"],
-        init_components=inputs["components"],
-        init_stretch=inputs["stretch"],
-    )
+    model.fit(source_matrix=source)
 
-    # Basic sanity check and the actual assertion
     assert np.isfinite(model.objective_function_)
-    assert model.objective_function_ < 5e6
+    assert np.allclose(
+        model.components_, expected_components, rtol=0.2, atol=0.1
+    )
+    assert np.allclose(model.weights_, expected_weights, rtol=0.2, atol=0.1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@sbillinge This PR was made with your comments [here](https://github.com/diffpy/diffpy.stretched-nmf/issues/180#issuecomment-4257569362) in mind. All test data is now self-contained. If we want to run on the real data, that can be something we do as part of the release process, but we no longer need to distribute large data files with the sdist.